### PR TITLE
Include `{i,u}32::reverse_bits`

### DIFF
--- a/posts/2019-08-15-Rust-1.37.0.md
+++ b/posts/2019-08-15-Rust-1.37.0.md
@@ -153,7 +153,7 @@ In Rust 1.37.0 there have been a number of standard library stabilizations:
 - [`Cell::as_slice_of_cells`]
 - [`DoubleEndedIterator::nth_back`]
 - [`Option::xor`]
-- [`{i,u}{8,16,64,128,size}::reverse_bits`] and [`Wrapping::reverse_bits`]
+- [`{i,u}{8,16,32,64,128,size}::reverse_bits`] and [`Wrapping::reverse_bits`]
 - [`slice::copy_within`]
 
 ### Other changes


### PR DESCRIPTION
**Library changes** lists {i,u}{8,16,64,128,size}::reverse_bits but not {i,u}32::reverse_bits.